### PR TITLE
BUG: Fix TCIABrowser with Slicer-4.11

### DIFF
--- a/TCIABrowser/TCIABrowser.py
+++ b/TCIABrowser/TCIABrowser.py
@@ -88,8 +88,10 @@ class TCIABrowserWidget(ScriptedLoadableModuleWidget):
     self.currentAPIKey = self.slicerApiKey
     item = qt.QStandardItem()
 
-    dicomAppWidget = ctk.ctkDICOMAppWidget()
-    databaseDirectory = dicomAppWidget.databaseDirectory
+    # Put the files downloaded from TCIA in the DICOM database folder by default.
+    # This makes downloaded files relocatable along with the DICOM database in
+    # recent Slicer versions.
+    databaseDirectory = slicer.dicomDatabase.databaseDirectory
     self.storagePath = databaseDirectory + "/TCIALocal/"
     if not os.path.exists(self.storagePath):
       os.makedirs(self.storagePath)
@@ -808,7 +810,10 @@ class TCIABrowserWidget(ScriptedLoadableModuleWidget):
     dicomWidget = slicer.modules.dicom.widgetRepresentation().self()
 
     indexer = ctk.ctkDICOMIndexer()
-    indexer.addDirectory(slicer.dicomDatabase, self.extractedFilesDirectory)
+    # DICOM indexer uses the current DICOM database folder as the basis for relative paths,
+    # therefore we must convert the folder path to absolute to ensure this code works
+    # even when a relative path is used as self.extractedFilesDirectory.
+    indexer.addDirectory(slicer.dicomDatabase, os.path.abspath(self.extractedFilesDirectory))
     indexer.waitForImportFinished()
     self.clearStatus()
 


### PR DESCRIPTION
DICOM database in Slicer-4.11 has been made relocatable. This works by storing relative paths for files that are within the DICOM database folder.
This changed how relative paths are interpreted (DICOM database folder is used as a basis), therefore we need to pass absolute paths to the DICOM indexer.

DICOM database now uses different path depending on database version, therefore we need to get the path from the Slicer DICOM database object
(not from a generic ctkDICOMAppWidget object).